### PR TITLE
Implement cross service trace contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,45 @@ app(\Illuminate\Bus\Dispatcher::class)->pipeThrough([
 ]);
 ```
 
+### Tracing Across Service Boundaries
+
+Trace contexts can easily be used across services. If your application starts a tracing context, that context can be
+carried over HTTP to another service with an OpenTracing compatible implementation.
+
+To automatically accept trace contexts from other services, add the tracing middleware to your application by adding it
+to your `app/Http/Kernel.php` file like below:
+
+```php
+<?php
+
+class Kernel extends HttpKernel
+{
+    protected $middleware = [
+        \LaravelOpenTracing\Http\Middleware\Tracing::class,
+    ];
+}
+```
+
+Assuming your application uses GuzzleHttp for sending requests to external services, you can use the provided tracing
+handler when creating the client like below. This will automatically send the necessary trace context headers with the
+HTTP request to the external service.
+
+```php
+<?php
+
+new \GuzzleHttp\Client(
+    [
+        'handler' => new \LaravelOpenTracing\TracingHandlerStack(),
+        'headers' => [
+            'cache-control' => 'no-cache',
+            'content-type' => 'application/json',
+        ],
+        'base_uri' => 'http://localhost/api/myservice',
+        'http_errors' => false
+    ]
+);
+```
+
 ## Testing
 
 docker run --rm -it -v $(pwd):/app php:5.6-cli-alpine /bin/sh -c 'apk add --no-cache $PHPIZE_DEPS && pecl install xdebug-2.5.5 && cd app && php -dzend_extension=xdebug.so vendor/bin/phpunit'

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
   ],
   "require": {
     "php": ">=5.6",
+    "guzzlehttp/guzzle": "^6.2",
     "illuminate/support": "^5.4.36",
     "jonahgeorge/jaeger-client-php": "dev-feature/php56",
     "opentracing/opentracing": "^1.0.0-beta5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95b106d4a7ccbfe74a0305edcd09139f",
+    "content-hash": "e7005ef9583d2d9af474efcf0b2ec08e",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -118,6 +118,189 @@
                 "parser"
             ],
             "time": "2019-03-17T18:48:37+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.4",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2018-04-22T15:46:56+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20T10:07:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "9f83dded91781a01c63574e387eaa769be769115"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9f83dded91781a01c63574e387eaa769be769115",
+                "reference": "9f83dded91781a01c63574e387eaa769be769115",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2018-12-04T20:46:45+00:00"
         },
         {
             "name": "jonahgeorge/jaeger-client-php",
@@ -809,6 +992,56 @@
             "time": "2016-08-06T20:24:11+00:00"
         },
         {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.1.0",
             "source": {
@@ -854,6 +1087,46 @@
                 "psr-3"
             ],
             "time": "2018-11-20T15:27:04+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7.0",
+                "satooshi/php-coveralls": ">=1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2016-02-11T07:05:27+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -2022,189 +2295,6 @@
             "time": "2015-06-14T21:17:01+00:00"
         },
         {
-            "name": "guzzlehttp/guzzle",
-            "version": "6.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
-                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.4",
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "ext-curl": "*",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
-                "psr/log": "^1.0"
-            },
-            "suggest": {
-                "psr/log": "Required for using the Log middleware"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.3-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle is a PHP HTTP client library",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "rest",
-                "web service"
-            ],
-            "time": "2018-04-22T15:46:56+00:00"
-        },
-        {
-            "name": "guzzlehttp/promises",
-            "version": "v1.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/promises.git",
-                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
-                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle promises library",
-            "keywords": [
-                "promise"
-            ],
-            "time": "2016-12-20T10:07:11+00:00"
-        },
-        {
-            "name": "guzzlehttp/psr7",
-            "version": "1.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9f83dded91781a01c63574e387eaa769be769115"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9f83dded91781a01c63574e387eaa769be769115",
-                "reference": "9f83dded91781a01c63574e387eaa769be769115",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0",
-                "psr/http-message": "~1.0",
-                "ralouphie/getallheaders": "^2.0.5"
-            },
-            "provide": {
-                "psr/http-message-implementation": "1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Psr7\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "homepage": "https://github.com/Tobion"
-                }
-            ],
-            "description": "PSR-7 message implementation that also provides common utility methods",
-            "keywords": [
-                "http",
-                "message",
-                "psr-7",
-                "request",
-                "response",
-                "stream",
-                "uri",
-                "url"
-            ],
-            "time": "2018-12-04T20:46:45+00:00"
-        },
-        {
             "name": "hamcrest/hamcrest-php",
             "version": "v2.0.0",
             "source": {
@@ -3044,96 +3134,6 @@
             ],
             "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
-        },
-        {
-            "name": "psr/http-message",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP messages",
-            "homepage": "https://github.com/php-fig/http-message",
-            "keywords": [
-                "http",
-                "http-message",
-                "psr",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "time": "2016-08-06T14:39:51+00:00"
-        },
-        {
-            "name": "ralouphie/getallheaders",
-            "version": "2.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ralouphie/getallheaders.git",
-                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
-                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~3.7.0",
-                "satooshi/php-coveralls": ">=1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/getallheaders.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ralph Khattar",
-                    "email": "ralph.khattar@gmail.com"
-                }
-            ],
-            "description": "A polyfill for getallheaders.",
-            "time": "2016-02-11T07:05:27+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/src/Http/Middleware/Tracing.php
+++ b/src/Http/Middleware/Tracing.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright 2019 Tais P. Hansen
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LaravelOpenTracing\Http\Middleware;
+
+use Illuminate\Http\Request;
+use LaravelOpenTracing\TracingService;
+
+class Tracing
+{
+    /**
+     * Handle incoming request and start a trace if the request contains a trace context.
+     *
+     * @param Request $request
+     * @param \Closure $next
+     * @return mixed
+     * @throws \Exception
+     */
+    public function handle(Request $request, \Closure $next)
+    {
+        /** @var TracingService $service */
+        $service = app(TracingService::class);
+
+        $context = null;
+        try {
+            $context = $service->extractFromHttpRequest($request);
+        } catch (\Exception $e) {
+            \Illuminate\Support\Facades\Log::warning(
+                'Failed getting trace context from request',
+                ['exception' => $e, 'header' => $request->header()]
+            );
+        }
+        if ($context === null) {
+            return $next($request);
+        }
+
+        return $service->trace(
+            'http.' . strtolower($request->getMethod()) . '.' . $request->decodedPath(),
+            static function () use ($next, $request) {
+                return $next($request);
+            },
+            ['child_of' => $context]
+        );
+    }
+}

--- a/src/TracingHandlerStack.php
+++ b/src/TracingHandlerStack.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright 2019 Tais P. Hansen
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LaravelOpenTracing;
+
+class TracingHandlerStack extends \GuzzleHttp\HandlerStack
+{
+    public function __construct(callable $handler = null)
+    {
+        parent::__construct($handler ?: \GuzzleHttp\choose_handler());
+
+        $this->push(
+            \GuzzleHttp\Middleware::mapRequest(
+                function (\Psr\Http\Message\RequestInterface $request) {
+                    foreach (app(TracingService::class)->getInjectHeaders() as $header => $value) {
+                        $request = $request->withHeader($header, $value);
+                    }
+                    return $request;
+                }
+            )
+        );
+    }
+}

--- a/tests/TracingHandlerStackTest.php
+++ b/tests/TracingHandlerStackTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright 2019 Tais P. Hansen
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace LaravelOpenTracing\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\Application;
+use LaravelOpenTracing\TracingHandlerStack;
+use LaravelOpenTracing\TracingService;
+use Mockery;
+
+class TracingHandlerStackTest extends \PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function testTraceContextHeadersAreSentInRequests()
+    {
+        /** @var Application|Mockery\Mock $app */
+        $app = Container::setInstance(Mockery::mock(Application::class, \ArrayAccess::class)->makePartial());
+
+        $service = Mockery::mock(TracingService::class)->makePartial();
+        $service->shouldReceive('getInjectHeaders')->once()
+            ->andReturn(['test-trace-id' => 'deadbeefdeadbeef:beefdeadbeefdead:0:1']);
+
+        $app->shouldReceive('make')->with(TracingService::class)->once()->andReturn($service);
+
+        $container = [];
+        $history = Middleware::history($container);
+
+        $handler = new TracingHandlerStack(new MockHandler([
+            new Response(200),
+        ]));
+        $handler->push($history);
+
+        $client = new Client(['handler' => $handler]);
+
+        $client->request('GET', 'http://localhost');
+
+        $this->assertEquals(
+            ['deadbeefdeadbeef:beefdeadbeefdead:0:1'],
+            $container[0]['request']->getHeader('test-trace-id')
+        );
+    }
+}

--- a/tests/TracingServiceProviderTest.php
+++ b/tests/TracingServiceProviderTest.php
@@ -11,6 +11,7 @@ namespace LaravelOpenTracing\Tests;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
+use LaravelOpenTracing\TracingHandlerStack;
 use LaravelOpenTracing\TracingService;
 use LaravelOpenTracing\TracingServiceProvider;
 use Mockery;

--- a/tests/TracingServiceTest.php
+++ b/tests/TracingServiceTest.php
@@ -8,10 +8,14 @@
 
 namespace LaravelOpenTracing\Tests;
 
+use Illuminate\Http\Request;
 use LaravelOpenTracing\TracingService;
 use Mockery;
 use OpenTracing\Scope;
+use OpenTracing\Span;
+use OpenTracing\SpanContext;
 use OpenTracing\Tracer;
+use const OpenTracing\Formats\HTTP_HEADERS;
 
 class TracingServiceTest extends \PHPUnit_Framework_TestCase
 {
@@ -52,5 +56,41 @@ class TracingServiceTest extends \PHPUnit_Framework_TestCase
         $service = new TracingService($tracer);
         $service->beginTrace('test.trace');
         $service->endTrace();
+    }
+
+    public function testGettingHeadersForInjection()
+    {
+        $spanContext = Mockery::mock(SpanContext::class);
+
+        $span = Mockery::mock(Span::class);
+        $span->shouldReceive('getContext')->withNoArgs()->once()->andReturn($spanContext);
+
+        $tracer = Mockery::mock(Tracer::class);
+        $tracer->shouldReceive('getActiveSpan')->withNoArgs()->once()->andReturn($span);
+        $tracer->shouldReceive('inject')
+            ->with($spanContext, HTTP_HEADERS, Mockery::on(function (&$array) {
+                $array['test-trace-id'] = 'beefdeadbeefdead:deadbeefdeadbeef:0:1';
+                return true;
+            }))->once();
+
+        $service = new TracingService($tracer);
+
+        $this->assertEquals(['test-trace-id' => 'beefdeadbeefdead:deadbeefdeadbeef:0:1'], $service->getInjectHeaders());
+    }
+
+    public function testExtractingHeadersFromRequest()
+    {
+        $spanContext = Mockery::mock(SpanContext::class);
+
+        $tracer = Mockery::mock(Tracer::class);
+        $tracer->shouldReceive('extract')
+            ->with(HTTP_HEADERS, ['test-trace-id' => 'deadbeefdeadbeef:beefdeadbeefdead:0:1'])
+            ->once()->andReturn($spanContext);
+
+        $service = new TracingService($tracer);
+
+        $request = new Request([], [], [], [], [], ['HTTP_TEST_TRACE_ID' => 'deadbeefdeadbeef:beefdeadbeefdead:0:1']);
+
+        $this->assertEquals($spanContext, $service->extractFromHttpRequest($request));
     }
 }


### PR DESCRIPTION
Adds middleware for Laravel and GuzzleHttp to automatically extract and
inject trace contexts for cross service tracing.